### PR TITLE
fix: handle private API changes for mongoose >= 5.5.14

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,8 @@ module.exports = function(schema) {
 
           schema.path(path).validate({
             validator: function() {
-              var arr = this.getValue(path + '.' + _path);
+              // handle private API changes for mongoose >= 5.5.14 Automattic/mongoose#7870
+              var arr = (this.$__getValue || this.getValue)(path + '.' + _path);
               var dup = hasDuplicates(arr);
               if (dup) {
                 return false;


### PR DESCRIPTION
Mongoose 5.5.14 (PR Automattic/mongoose#7870) changed private API from `getValue` to `$__getValue`

Fix #5
Fix Automattic/mongoose#7999
re: alexsk/mongoose-intl#20


I'm sorry because I have been making breaking changes recently and unexpected things happen.