### PR TITLE
critical fix: `this` scope inside $__getValue

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ module.exports = function(schema) {
           schema.path(path).validate({
             validator: function() {
               // handle private API changes for mongoose >= 5.5.14 Automattic/mongoose#7870
-              var arr = (this.$__getValue || this.getValue)(path + '.' + _path);
+              var arr = (this.$__getValue || this.getValue).call(this, path + '.' + _path);
               var dup = hasDuplicates(arr);
               if (dup) {
                 return false;


### PR DESCRIPTION
## Summary
It turns out that my previous fix #6 make `this` scope lost inside $__getValue() and causing problem: `Cannot read property '_doc' of undefined`

re: https://github.com/vkarpov15/mongoose-unique-array/pull/6#issuecomment-514314260
> No worries, it's bad that this project relied on `getValue()`. Would you be interested in figuring out how to get this project to not rely on private APIs?

I've investigated a little bit regarding not using private API.
I found [Document.prototype.get()](https://mongoosejs.com/docs/api/document.html#document_Document-get) promising. It has an option to bypass getters. I'm haven't tested it but it may work. I'm a little busy recently but I think this should be fixed first and publish asap.

## Important Issue

Also, 2 of the tests can't pass: ``Caveat With `push()` `` and  `with race condition`
Something is wrong in mongoose about array VersionError/DocumentNotFoundError.
Should be investigated. I enable debug and find mongoose doesn't use `__v` as condition in `save()` when executing `updateOne`.


```
  API
(node:26695) DeprecationWarning: collection.ensureIndex is deprecated. Use createIndexes instead.
    ✓ Basic Example (81ms)
    ✓ Why a Separate Plugin? (59ms)
    1) Caveat With `push()`

  arrayUnique
    ✓ pushing onto doc array (60ms)
    2) with race condition
    ✓ with new docs
    ✓ nested
    ✓ with array set to null (gh-1) (113ms)


  6 passing (752ms)
  2 failing

  1) API
       Caveat With `push()`:
     Uncaught AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:

  assert.ok(error)

      at /home/fonger/mongoose-unique-array/test/examples.test.js:128:22
      at /home/fonger/mongoose-unique-array/node_modules/mongoose/lib/model.js:4567:16
      at /home/fonger/mongoose-unique-array/node_modules/mongoose/lib/utils.js:264:16
      at model.$__save.error (node_modules/mongoose/lib/model.js:475:7)
      at /home/fonger/mongoose-unique-array/node_modules/kareem/index.js:315:21
      at next (node_modules/kareem/index.js:209:27)
      at /home/fonger/mongoose-unique-array/node_modules/kareem/index.js:182:9
      at process.nextTick (node_modules/kareem/index.js:499:38)
      at process._tickCallback (internal/process/next_tick.js:61:11)

  2) arrayUnique
       with race condition:
     Uncaught AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:

  assert.ok(error)

      at /home/fonger/mongoose-unique-array/test/index.test.js:67:22
      at /home/fonger/mongoose-unique-array/node_modules/mongoose/lib/model.js:4567:16
      at /home/fonger/mongoose-unique-array/node_modules/mongoose/lib/utils.js:264:16
      at model.$__save.error (node_modules/mongoose/lib/model.js:475:7)
      at /home/fonger/mongoose-unique-array/node_modules/kareem/index.js:315:21
      at next (node_modules/kareem/index.js:209:27)
      at /home/fonger/mongoose-unique-array/node_modules/kareem/index.js:182:9
      at process.nextTick (node_modules/kareem/index.js:499:38)
      at process._tickCallback (internal/process/next_tick.js:61:11)

```